### PR TITLE
suppressSequenceNumber

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -167,6 +167,10 @@ single-valued list with the specified value. The supported_versions extension is
 omitted from ClientHello.extensions and reconstructed in the transcript with the
 specified value.
 
+suppressSequenceNumber (boolean):
+: If present and set to true, the sequence number field is omitted 
+from encrypted record headers.
+
 cipherSuite (string):
 : indicates that both sides agree to
 the single named cipher suite, using the "TLS_AEAD_HASH" syntax
@@ -419,7 +423,7 @@ transports length information may be inferred from the underlying layer.
 
 Normal DTLS does not provide a mechanism for suppressing the sequence number
 field entirely.  In cases where a sequence number is not required (e.g., when a
-reliable transport is in use), a cTLS implementation may suppress it by setting
+reliable transport is in use), a cTLS implementation MUST suppress it by setting
 the `suppressSequenceNumber` flag in the compression profile being used (see
 {{template-based-specialization}}).  When this flag is enabled, the S bit in the
 configuration octet MUST be cleared.

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -418,14 +418,14 @@ As with DTLS, the length field MAY be omitted by clearing the L bit, which means
 that the record consumes the entire rest of the data in the lower level
 transport.  In this case it is not possible to have multiple DTLSCiphertext
 format records without length fields in the same datagram.  In stream-oriented
-transports (e.g., TCP), the length field MUST be present. For use over other 
-transports length information may be inferred from the underlying layer. 
+transports (e.g., TCP), the length field MUST be present. For use over other
+transports length information may be inferred from the underlying layer.
 
 Normal DTLS does not provide a mechanism for suppressing the sequence number
 field entirely.  When cTLS is used on top of a reliable transport, sequence
-numbers are suppressed and the `suppressSequenceNumber` flag in the compression
-profile is set (see {{template-based-specialization}}).  Consequently, the 
-the S bit MUST be cleared.
+numbers MUST be suppressed and the `suppressSequenceNumber` flag in the
+compression profile is set (see {{template-based-specialization}}).
+Consequently, the the S bit MUST be cleared.
 
 
 ## Handshake Layer

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -422,11 +422,10 @@ transports (e.g., TCP), the length field MUST be present. For use over other
 transports length information may be inferred from the underlying layer. 
 
 Normal DTLS does not provide a mechanism for suppressing the sequence number
-field entirely.  In cases where a sequence number is not required (e.g., when a
-reliable transport is in use), a cTLS implementation MUST suppress it by setting
-the `suppressSequenceNumber` flag in the compression profile being used (see
-{{template-based-specialization}}).  When this flag is enabled, the S bit in the
-configuration octet MUST be cleared.
+field entirely.  When cTLS is used on top of a reliable transport, sequence
+numbers are suppressed and the `suppressSequenceNumber` flag in the compression
+profile is set (see {{template-based-specialization}}).  Consequently, the 
+the S bit MUST be cleared.
 
 
 ## Handshake Layer


### PR DESCRIPTION
Added the suppressSequenceNumber element to the template-based specialization since it was accidentially delete. 
Mandatory suppression of sequence numbers when reliable transports are used.