### PR TITLE
Replace suppressSequenceNumber with transport-specific behavior

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -410,7 +410,7 @@ transports (e.g., TCP), the length field MUST be present. For use over other
 transports length information may be inferred from the underlying layer. 
 
 Normal DTLS does not provide a mechanism for suppressing the sequence number
-field entirely. When a reliable transport (e.g., TCP) is in use, the
+field entirely. When a reliable, ordered transport (e.g., TCP) is in use, the
 S bit in the configuration octet MUST be cleared and the sequence number
 MUST be omitted. When an unreliable transport is in use, the S bit
 has its usual meaning and the sequence number MUST be included.

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -410,11 +410,10 @@ transports (e.g., TCP), the length field MUST be present. For use over other
 transports length information may be inferred from the underlying layer. 
 
 Normal DTLS does not provide a mechanism for suppressing the sequence number
-field entirely.  In cases where a sequence number is not required (e.g., when a
-reliable transport is in use), a cTLS implementation may suppress it by setting
-the `suppressSequenceNumber` flag in the compression profile being used (see
-{{template-based-specialization}}).  When this flag is enabled, the S bit in the
-configuration octet MUST be cleared.
+field entirely. When a reliable transport (e.g., TCP) is in use, the
+S bit in the configuration octet MUST be cleared and the sequence number
+MUST be omitted. When an unreliable transport is in use, the S bit
+has its usual meaning and the sequence number MUST be included.
 
 
 ## Handshake Layer


### PR DESCRIPTION
I'm slightly concerned about the fact that we have two different wire behaviors with the same transcript, but because the integrity tag includes the header, I think it's OK.

@martinthomson would welcome your thoughts.