### PR TITLE
Remove "baseline TLS" handshake reconstruction

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -159,7 +159,7 @@ The following elements are defined:
 profile (string):
 : identifies the profile being defined (default: ""). If present, this key MUST
 contain a hex-encoded sequence of 0-255 bytes (the "profile ID"). IDs whose
-decoded length is 4 bytes or less are reserved (see {{reserved-templates}}). When a
+decoded length is 4 bytes or less are reserved (see {{reserved-profiles}}). When a
 reserved value is used (including the default value), other keys MUST NOT appear
 in the template, and a client MUST NOT accept the template unless it recognizes
 the ID.
@@ -382,7 +382,7 @@ records, and other protocols using the same 5-tuple.
       } CTLSPlaintext;
 ~~~~
 
-Encrypted records use DTLS {{!I-D.draft-ietf-tls-dtls}} 1.3 record framing, comprising a configuration octet
+Encrypted records use DTLS {{!I-D.ietf-tls-dtls13}} 1.3 record framing, comprising a configuration octet
 followed by optional connection ID, sequence number, and length fields. The
 encryption process and additional data are also as described in DTLS.
 
@@ -601,14 +601,16 @@ with the following columns:
 * Note: An explanation or reference.
 
 The ID value of length 1 are subject to a "Standards Action" registry
-policy. Values of length 2 are subject to an "RFC Required" policy. Other
-values are subject to a "First Come First Served" policy.
+policy. Values of length 2 are subject to an "RFC Required" policy. Values
+of length 3 and 4 are subject to a "First Come First Served" policy. Values
+longer than 4 octets are not subject to registration and MUST NOT appear
+in this registry.
 
 The initial registry contents are:
 
-| ID value  | Template         | Note          |
-|:=========:|:================:|:=============:|
-| 0x00      | {"version": 772} | cTLS 1.3-only |
+| ID value  | Template           | Note          |
+|:=========:|:==================:|:=============:|
+| `[0x00]`  | `{"version": 772}` | cTLS 1.3-only |
 
 --- back
 

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -147,7 +147,7 @@ enum {
   signature_algorithm(4),
   random(5),
   mutual_auth(6),
-  extension_order(7),
+  handshake_framing(7),
   client_hello_extensions(8),
   server_hello_extensions(9),
   encrypted_extensions(10),
@@ -166,6 +166,8 @@ struct {
   CTLSTemplateElement elements<0..2^32-1>
 } CTLSTemplate;
 ~~~~
+
+> TODO: Reorder enum.
 
 Elements in a `CTLSTemplate` MUST appear in strictly ascending order.
 The initial elements are defined in the subsections below.  Future elements can be
@@ -194,6 +196,8 @@ supported_versions extensions in the ClientHello and ServerHello would be omitte
 ~~~~
 
 ### Initial template elements
+
+> TODO: Reorder section.
 
 #### `profile`
 

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -171,7 +171,8 @@ struct {
 
 Elements in a `CTLSTemplate` MUST appear in strictly ascending order.
 The initial elements are defined in the subsections below.  Future elements can be
-added via an IANA registry.  When generating a template, all elements are OPTIONAL
+added via an IANA registry ({{template-keys}}).  When generating a
+template, all elements are OPTIONAL
 to include.  When processing a template, all elements are mandatory
 to understand (but see discussion of `optional` in {{optional}}).
 
@@ -725,26 +726,23 @@ the value XXXX to the RFC number assigned for this document.
 
 This document requests that IANA open a new registry entitled "cTLS Template Keys", on the Transport Layer Security (TLS) Parameters page, with a "Specification Required" registration policy and the following initial contents:
 
-FIXME: Need integers.
-
-| Key                    | JSON Type    | Reference       |
-|:======================:|:============:|:================|
-| profile                | string       | (This document) |
-| version                | number       | (This document) |
-| cipherSuite            | string       | (This document) |
-| dhGroup                | string       | (This document) |
-| signatureAlgorithm     | string       | (This document) |
-| random                 | number       | (This document) |
-| mutualAuth             | true/false   | (This document) |
-| extension_order        | object       | (This document) |
-| clientHelloExtensions  | object       | (This document) |
-| serverHelloExtensions  | object       | (This document) |
-| encryptedExtensions    | object       | (This document) |
-| certRequestExtensions  | object       | (This document) |
-| knownCertificates      | object       | (This document) |
-| finishedSize           | number       | (This document) |
-| handshakeFraming       | true/false   | (This document) |
-| optional               | object       | (This document) |
+| Name                    | Value    | Reference       |
+|:=======================:|:========:|:================|
+| profile                 | 0        | (This document) |
+| version                 | 1        | (This document) |
+| cipher_suite            | 2        | (This document) |
+| dh_group                | 3        | (This document) |
+| signature_algorithm     | 4        | (This document) |
+| random                  | 5        | (This document) |
+| mutual_auth             | 6        | (This document) |
+| handshake_framing       | 7        | (This document) |
+| client_hello_extensions | 8        | (This document) |
+| server_hello_extensions | 9        | (This document) |
+| encrypted_extensions    | 10       | (This document) |
+| cert_request_extensions | 11       | (This document) |
+| known_certificates      | 12       | (This document) |
+| finished_size           | 13       | (This document) |
+| optional                | 65535    | (This document) |
 
 ## Adding a cTLS Template message type
 

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -131,7 +131,7 @@ the cTLS protocol exchange, the amount of data exchanged can be radically reduce
 Because different clients may use different compression templates and because multiple 
 compression templates may be available for use in different deployment environments, 
 a client needs to inform the server about the profile it is planning to use. The 
-profile field in the ClientHello serves this purpose. 
+profile_id field in the ClientHello serves this purpose.
 
 Although the template-based specialization mechanisms described here are general,
 we also include specific mechanism for certificate-based exchanges because those are
@@ -148,15 +148,21 @@ supported_versions extensions in the ClientHello and ServerHello would be omitte
 
 ~~~~JSON
 {
-   "version" : 772,
-   "cipherSuite" : "TLS_AES_128_GCM_SHA256"
+  "profile": "0001020304050607",
+  "version": 772,
+  "cipherSuite": "TLS_AES_128_GCM_SHA256"
 }
 ~~~~
 
 The following elements are defined: 
 
-profile (integer): 
-: identifies the profile being defined. 
+profile (string):
+: identifies the profile being defined (default: ""). If present, this key MUST
+contain a hex-encoded sequence of 0-255 bytes (the "profile ID"). IDs whose
+decoded length is 4 bytes or less are reserved (see {{reserved-templates}}). When a
+reserved value is used (including the default value), other keys MUST NOT appear
+in the template, and a client MUST NOT accept the template unless it recognizes
+the ID.
 
 version (integer):
 : indicates that both sides agree to the
@@ -376,10 +382,6 @@ records, and other protocols using the same 5-tuple.
       } CTLSPlaintext;
 ~~~~
 
-[[OPEN ISSUE: The profile_id is needed in the ClientHello to inform the server
-what compression profile to use. For a ServerHello this field is not required. 
-Should we make this field optional?]]
-
 Encrypted records use DTLS {{!I-D.draft-ietf-tls-dtls}} 1.3 record framing, comprising a configuration octet
 followed by optional connection ID, sequence number, and length fields. The
 encryption process and additional data are also as described in DTLS.
@@ -476,13 +478,8 @@ The cTLS ClientHello is defined as follows.
       } ClientHello;
 ~~~~
 
-The client uses the `profile_id` field to inform the server
-about the compression profile being used (see
-{{template-based-specialization}}).  This field MUST be set to
-a zero-length value and only if no compression profile is used.  Non zero-length
-values are agreed out of band between the client and server,
-as part of the specification of the compression profile.
-
+The `profile_id` field MUST identify the profile that is in use. A
+zero-length ID corresponds to the cTLS default protocol.
 
 
 ## ServerHello
@@ -522,7 +519,7 @@ else is ordinary TLS 1.3.
 
 ~~~~JSON
 {
-   "profile" : 1,
+   "profile": "0504030201",
    "version" : 772,
    "random": 16,
    "cipherSuite" : "TLS_AES_128_GCM_SHA256",
@@ -537,8 +534,6 @@ else is ordinary TLS 1.3.
 
 Version 772 corresponds to the hex representation 0x0304, named group "29"
 (0x001D) represents X25519.
-
-[[OPEN ISSUE: Should we have a registry of well-known profiles?]]
 
 # Security Considerations
 
@@ -579,7 +574,7 @@ This document requests that IANA open a new registry entitled "cTLS Template Key
 
 | Key                    | JSON Type    | Reference       |
 |:======================:|:============:|:================|
-| profile                | number       | (This document) |
+| profile                | string       | (This document) |
 | version                | number       | (This document) |
 | cipherSuite            | string       | (This document) |
 | dhGroup                | string       | (This document) |
@@ -594,6 +589,26 @@ This document requests that IANA open a new registry entitled "cTLS Template Key
 | knownCertificates      | object       | (This document) |
 | finishedSize           | number       | (This document) |
 | optional               | object       | (This document) |
+
+## Reserved profiles
+
+This document requests that IANA open a new registry entitled "Well-known
+cTLS Profile IDs", on the Transport Layer Security (TLS) Parameters page,
+with the following columns:
+
+* ID value: A sequence of 1-4 octets.
+* Template: A JSON object.
+* Note: An explanation or reference.
+
+The ID value of length 1 are subject to a "Standards Action" registry
+policy. Values of length 2 are subject to an "RFC Required" policy. Other
+values are subject to a "First Come First Served" policy.
+
+The initial registry contents are:
+
+| ID value  | Template         | Note          |
+|:=========:|:================:|:=============:|
+| 0x00      | {"version": 772} | cTLS 1.3-only |
 
 --- back
 
@@ -625,7 +640,7 @@ The following compression profile was used in this example:
 
 ~~~~~JSON
 {
-  "profile": 1, 
+  "profile": "abcdef1234",
   "version": 772,
   "cipherSuite": "TLS_AES_128_CCM_8_SHA256",
   "dhGroup": "X25519",
@@ -658,20 +673,22 @@ The following compression profile was used in this example:
 }
 ~~~~~
 
-ClientHello: 36 bytes = DH(32) + Overhead(4)
+ClientHello: 73 bytes = Profile ID(5) + Random(32) + DH(32) + Overhead(4)
 
 ~~~
-01                    // ClientHello
-01                    // Profile ID
+01                    // Handshake.msg_type = ClientHello
+05 abcdef1234         // ClientHello.profile_id
+5856a1...43168c130    // ClientHello.random
 0020 a690...af948     // KeyShareEntry.key_exchange
 ~~~
 
-ServerHello: 36 = DH(32) + Overhead(4)
+ServerHello: 68 bytes = Random(32) + DH(32) + Overhead(4)
 
 ~~~
-02                 // ServerHello
-26                 // Extensions.length
-0020 9fbc...0f49   // KeyShareEntry.key_exchange
+02                     // Handshake.msg_type = ServerHello
+cff4c0...684c859ca8    // ServerHello.random
+26                     // Extensions.length
+0020 9fbc...0f49       // KeyShareEntry.key_exchange
 ~~~
 
 Server Flight: 80 = SIG(64) + MAC(8) + CERTID(1) + Overhead(7)

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -445,6 +445,8 @@ there can only be one `dh_group`.
 * `extension_type` is omitted because it is specified by `expected_extensions`
 * The length of `extensions` is omitted because `allow_additional` is false, the number of items in `extensions` (i.e., 1) is known in advance.
 
+The only exception to this rule is `ClientHello.profile_id`, which is processed before the profile is known.
+
 ## Record Layer
 
 The only cTLS records that are sent in plaintext are handshake records

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -600,7 +600,7 @@ with the following columns:
 * Template: A JSON object.
 * Note: An explanation or reference.
 
-The ID value of length 1 are subject to a "Standards Action" registry
+The ID values of length 1 are subject to a "Standards Action" registry
 policy. Values of length 2 are subject to an "RFC Required" policy. Values
 of length 3 and 4 are subject to a "First Come First Served" policy. Values
 longer than 4 octets are not subject to registration and MUST NOT appear


### PR DESCRIPTION
This is a radical change that attempts to implement the (possible)
consensus to move from a "reconstruction-based" transcript to a
"non-reconstruction" transcript.  Verifying the transcript without
reconstruction requires the transcript to include the template,
which requires a byte-identical representation of the template.
This change makes this possible by introducing a stable binary
representation of the template, with JSON as a human-readable
alternative.

This change also attempts to:
* Formalize the notion of when vector lengths can be omitted
* Rearrange the extension templating in a more convenient fashion

Fixes #57
