### PR TITLE
More static vectors for additional extensions

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -305,7 +305,7 @@ Value: a single `CTLSExtensionTemplate` struct:
 struct {
   Extension predefined_extensions<0..2^16-1>;
   ExtensionType expected_extensions<0..2^16-1>;
-  ExtensionType known_self_delimiting_extensions<0..2^16-1>;
+  ExtensionType self_delimiting_extensions<0..2^16-1>;
   uint8 allow_additional;
 } CTLSExtensionTemplate;
 ~~~~
@@ -319,7 +319,7 @@ in the corresponding message, at the beginning of its `extensions` field.
 The types of these extensions are omitted when serializing the `extensions`
 field of the corresponding message.
 
-The `known_self_delimiting_extensions` field indicates extensions whose data is
+The `self_delimiting_extensions` field indicates extensions whose data is
 self-delimiting. The cTLS implementation MUST be able to parse all these
 extensions, and all extensions listed in {{Section 4.2 of !RFC8446}}.
 
@@ -338,7 +338,7 @@ treatment, as opposed to hex values.
 Static vectors (see {{static-vectors}}):
 
 * `Extension.extension_data` for any extension whose type is in
-  `omit_length`, or is listed in
+  `self_delimiting_extensions`, or is listed in
   {{Section 4.2 of !RFC8446}} except `padding`.  This applies only to the corresponding message.
 * The `extensions` field of the corresponding message, if `allow_additional` is false.
 
@@ -346,6 +346,7 @@ In JSON, this value is represented as a dictionary with three keys:
 
 * `predefinedExtensions`: a dictionary mapping `ExtensionType` names ({{!RFC8446, Section 4.2}}) to values encoded as hexadecimal strings.
 * `expectedExtensions`: an array of `ExtensionType` names.
+* `selfDelimitingExtensions`: an array of `ExtensionType` names.
 * `allowAdditional`: `true` or `false`.
 
 If `predefinedExtensions` or `expectedExtensions` is empty, it MAY be omitted.

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -305,6 +305,7 @@ Value: a single `CTLSExtensionTemplate` struct:
 struct {
   Extension predefined_extensions<0..2^16-1>;
   ExtensionType expected_extensions<0..2^16-1>;
+  ExtensionType known_self_delimiting_extensions<0..2^16-1>;
   uint8 allow_additional;
 } CTLSExtensionTemplate;
 ~~~~
@@ -317,6 +318,10 @@ The `expected_extensions` field indicates extensions that must be included
 in the corresponding message, at the beginning of its `extensions` field.
 The types of these extensions are omitted when serializing the `extensions`
 field of the corresponding message.
+
+The `known_self_delimiting_extensions` field indicates extensions whose data is
+self-delimiting. The cTLS implementation MUST be able to parse all these
+extensions, and all extensions listed in {{Section 4.2 of !RFC8446}}.
 
 The `allow_additional` field MUST be 0 (false) or 1 (true), indicating whether
 additional extensions are allowed here.
@@ -333,6 +338,9 @@ treatment, as opposed to hex values.
 Static vectors (see {{static-vectors}}):
 
 * `Extension.extension_data` for any extension in `expected_extensions` whose value is self-delimiting (e.g., fixed length).  This applies only to the corresponding message.
+* `Extension.extension_data` for any additional extension whose type is in
+  `known_self_delimiting_extensions`, or is listed in
+  {{Section 4.2 of !RFC8446}} except `padding`.
 * The `extensions` field of the corresponding message, if `allow_additional` is false.
 
 In JSON, this value is represented as a dictionary with three keys:
@@ -442,12 +450,6 @@ Some cTLS template elements imply that certain vectors (as defined in {{!RFC8446
 Section 3.4}}) have a fixed number of elements during the handshake.  These
 template elements note these "static vectors" in their definition.  When encoding
 a "static vector", its length prefix is omitted.
-
-In addition to the static vectors implied by various template elements,
-`Extension.extension_data` is always static in cTLS if the extension is any
-type listed in {{Section 4.2 of !RFC8446}} except `padding`.  cTLS implementations
-MUST be able to parse any of these extensions that the other party is permitted to
-send, but no other support is required.
 
 For example, suppose that the cTLS template is:
 

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -337,10 +337,9 @@ treatment, as opposed to hex values.
 
 Static vectors (see {{static-vectors}}):
 
-* `Extension.extension_data` for any extension in `expected_extensions` whose value is self-delimiting (e.g., fixed length).  This applies only to the corresponding message.
-* `Extension.extension_data` for any additional extension whose type is in
-  `known_self_delimiting_extensions`, or is listed in
-  {{Section 4.2 of !RFC8446}} except `padding`.
+* `Extension.extension_data` for any extension whose type is in
+  `omit_length`, or is listed in
+  {{Section 4.2 of !RFC8446}} except `padding`.  This applies only to the corresponding message.
 * The `extensions` field of the corresponding message, if `allow_additional` is false.
 
 In JSON, this value is represented as a dictionary with three keys:


### PR DESCRIPTION
In the case a cTLS handshake uses a self-delimiting extension (in additional extensions) that is not present in section 4.2 of RFC 8446, its length is always serialized.

With this PR, the type of this extension can be stored in `known_self_delimiting_extensions` and its length can be omitted.