### PR TITLE
More precise static vectors for dh_group and signature_algorithm

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -247,7 +247,7 @@ struct {
 ~~~~
 
 This is equivalent to adding a "supported_groups" extension to every message
-where that is allowed (i.e. ClientHello and EncryptedExtensions, in TLS 1.3) 
+where that is allowed (i.e. ClientHello and EncryptedExtensions, in TLS 1.3)
 consisting solely of the group `CTLSKeyShareGroup.group_name`.
 
 Static vectors (see {{static-vectors}}):

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -237,36 +237,53 @@ defined in {{RFC8446, Section 8.4}}.
 
 #### `dh_group`
 
-Value: a single `NamedGroup` ({{!RFC8446, Section 4.2.7}}) to use for key establishment.
+Value: a single `CTLSDhGroup` to use for key establishment.
+
+~~~~
+struct {
+    NamedGroup group_name;
+    uint16 key_length;
+} CTLSDhGroup;
+~~~~
 
 This is equivalent to a literal "supported_groups" extension
-consisting solely of this group.
+consisting solely of the group `CTLSDhGroup.group_name`.
 
 Static vectors (see {{static-vectors}}):
 
 * `KeyShareClientHello.client_shares`
-* `KeyShareEntry.key_exchange`, if the `NamedGroup` uses fixed-size key shares.
+* `KeyShareEntry.key_exchange`, if `CTLSDhGroup.key_length` is non-zero.
 
-In JSON, the group is listed by the code point name in {{RFC8446, Section 4.2.7}}
-(e.g., "x25519").
+In JSON, this value is represented as a dictionary with two keys:
+* `groupName`: a string containing the code point name in {{RFC8446, Section 4.2.7}} (e.g., "x25519")
+* `keyLength`: an integer
 
 #### `signature_algorithm`
 
-Value: a single `SignatureScheme` ({{!RFC8446, Section 4.2.3}}) to use for authentication.
+Value: a single `CTLSSignatureAlgorithm` to use for authentication.
+
+~~~~
+struct {
+    SignatureScheme signature_scheme;
+    uint16 signature_length;
+} CTLSSignatureAlgorithm;
+~~~~
 
 This is equivalent to a placing a literal "signature_algorithms" extension
-consisting solely of this group in every extensions field where it is
+consisting solely of `CTLSSignatureAlgorithm.signature_scheme` in every extensions field where it is
 permitted to appear.  When this element is included,
 `CertificateVerify.algorithm` is omitted.
 
 Static vectors (see {{static-vectors}}):
 
-* `CertificateVerify.signature`, if the `SignatureScheme` output is
-  self-delimiting.
+* `CertificateVerify.signature`, if `CTLSSignatureAlgorithm.signature_length` is non-zero.
 
 In JSON, the
 signature algorithm is listed by the code point name in {{RFC8446,
 Section 4.2.3}}. (e.g., ecdsa_secp256r1_sha256).
+In JSON, this value is represented as a dictionary with two keys:
+* `signatureScheme`: a string containing the code point name in {{RFC8446, Section 4.2.3}}. (e.g., ecdsa_secp256r1_sha256).
+* `signatureLength`: an integer.
 
 #### `random`
 

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -246,7 +246,8 @@ struct {
 } CTLSKeyShareGroup;
 ~~~~
 
-This is equivalent to a literal "supported_groups" extension in ClientHello
+This is equivalent to adding a "supported_groups" extension to every message
+where that is allowed (i.e. ClientHello and EncryptedExtensions, in TLS 1.3) 
 consisting solely of the group `CTLSKeyShareGroup.group_name`.
 
 Static vectors (see {{static-vectors}}):

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -237,22 +237,22 @@ defined in {{RFC8446, Section 8.4}}.
 
 #### `dh_group`
 
-Value: a single `CTLSDhGroup` to use for key establishment.
+Value: a single `CTLSKeyShareGroup` to use for key establishment.
 
 ~~~~
 struct {
     NamedGroup group_name;
-    uint16 key_length;
-} CTLSDhGroup;
+    uint16 key_share_length;
+} CTLSKeyShareGroup;
 ~~~~
 
-This is equivalent to a literal "supported_groups" extension
-consisting solely of the group `CTLSDhGroup.group_name`.
+This is equivalent to a literal "supported_groups" extension in ClientHello
+consisting solely of the group `CTLSKeyShareGroup.group_name`.
 
 Static vectors (see {{static-vectors}}):
 
 * `KeyShareClientHello.client_shares`
-* `KeyShareEntry.key_exchange`, if `CTLSDhGroup.key_length` is non-zero.
+* `KeyShareEntry.key_exchange`, if `CTLSKeyShareGroup.key_share_length` is non-zero.
 
 In JSON, this value is represented as a dictionary with two keys:
 * `groupName`: a string containing the code point name from the TLS Supported Groups registry (e.g., "x25519").

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -255,8 +255,8 @@ Static vectors (see {{static-vectors}}):
 * `KeyShareEntry.key_exchange`, if `CTLSDhGroup.key_length` is non-zero.
 
 In JSON, this value is represented as a dictionary with two keys:
-* `groupName`: a string containing the code point name in {{RFC8446, Section 4.2.7}} (e.g., "x25519")
-* `keyLength`: an integer
+* `groupName`: a string containing the code point name from the TLS Supported Groups registry (e.g., "x25519").
+* `keyLength`: an integer, defaulting to zero if omitted.
 
 #### `signature_algorithm`
 
@@ -270,8 +270,8 @@ struct {
 ~~~~
 
 This is equivalent to a placing a literal "signature_algorithms" extension
-consisting solely of `CTLSSignatureAlgorithm.signature_scheme` in every extensions field where it is
-permitted to appear.  When this element is included,
+consisting solely of `CTLSSignatureAlgorithm.signature_scheme` in every extensions field where the "signature_algorithms" extension is
+permitted to appear (i.e. ClientHello and CertificateRequest, in TLS 1.3).  When this element is included,
 `CertificateVerify.algorithm` is omitted.
 
 Static vectors (see {{static-vectors}}):
@@ -282,8 +282,8 @@ In JSON, the
 signature algorithm is listed by the code point name in {{RFC8446,
 Section 4.2.3}}. (e.g., ecdsa_secp256r1_sha256).
 In JSON, this value is represented as a dictionary with two keys:
-* `signatureScheme`: a string containing the code point name in {{RFC8446, Section 4.2.3}}. (e.g., ecdsa_secp256r1_sha256).
-* `signatureLength`: an integer.
+* `signatureScheme`: a string containing the code point name in the TLS SignatureScheme registry (e.g., "ecdsa_secp256r1_sha256").
+* `signatureLength`: an integer, defaulting to zero if omitted.
 
 #### `random`
 

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -257,7 +257,7 @@ Static vectors (see {{static-vectors}}):
 
 In JSON, this value is represented as a dictionary with two keys:
 * `groupName`: a string containing the code point name from the TLS Supported Groups registry (e.g., "x25519").
-* `keyLength`: an integer, defaulting to zero if omitted.
+* `keyShareLength`: an integer, defaulting to zero if omitted.
 
 #### `signature_algorithm`
 
@@ -473,7 +473,10 @@ For example, suppose that the cTLS template is:
 {
   "ctlsVersion": 0,
   "version": 772,
-  "dhGroup": "x25519",
+  "dhGroup": {
+    "groupName": "x25519",
+    "keyShareLength": 32
+  },
   "clientHelloExtensions": {
     "expectedExtensions": ["key_share"],
     "allowAdditional": false
@@ -742,7 +745,10 @@ else is ordinary TLS 1.3.
    "version" : 772,
    "random": 16,
    "cipherSuite" : "TLS_AES_128_GCM_SHA256",
-   "dhGroup": "x25519",
+   "dhGroup": {
+     "groupName": "x25519",
+     "keyShareLength": 32
+   },
    "clientHelloExtensions": {
       "predefinedExtensions": {
           "application_layer_protocol_negotiation" : "030016832",
@@ -887,8 +893,14 @@ The following compression profile was used in this example:
   "profile": "abcdef1234",
   "version": 772,
   "cipherSuite": "TLS_AES_128_CCM_8_SHA256",
-  "dhGroup": "x25519",
-  "signatureAlgorithm": "ecdsa_secp256r1_sha256",
+  "dhGroup": {
+    "groupName": "x25519",
+    "keyShareLength": 32
+  },
+  "signatureAlgorithm": {
+    "signatureScheme": "ecdsa_secp256r1_sha256",
+    "signatureLength": 64
+  },
   "finishedSize": 8,
   "clientHelloExtensions": {
     "predefinedExtensions": {


### PR DESCRIPTION
As proposed by @bemasc in #79, for the same reasons explained in #78, this PR makes more explicit the static vectors for `dh_group` and `signature_algorithm`.

I am still not convinced by the sentence "in every extensions field where it is permitted to appear" which is still vague, however I don't have the expertise in TLS necessary to make this less ambiguous and explicitly say what messages are modified.