### PR TITLE
Removed the remark about point compression

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -73,6 +73,7 @@ is achieved by five basic techniques:
 - More compact encodings.
 - A template-based specialization mechanism that allows pre-populating information
   at both endpoints without the need for negotiation.
+- Alternative cryptographic techniques, such as nonce truncation. 
 
 For the common (EC)DHE handshake with pre-established certificates, Stream cTLS
 achieves an overhead of 45 bytes over the minimum required by the

--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -70,12 +70,9 @@ is achieved by five basic techniques:
   of TLS.
 - Omitting the fields and handshake messages required for preserving backwards-compatibility
   with earlier TLS versions.
-- More compact encodings, for example point compression.
+- More compact encodings.
 - A template-based specialization mechanism that allows pre-populating information
   at both endpoints without the need for negotiation.
-- Alternative cryptographic techniques, such as semi-static Diffie-Hellman.
-
-> OPEN ISSUE: Semi-static and point compression are never mentioned again.
 
 For the common (EC)DHE handshake with pre-established certificates, Stream cTLS
 achieves an overhead of 45 bytes over the minimum required by the


### PR DESCRIPTION

We have decided to moved the compressed elliptic curve representations to an external draft since the issue is equally applicable to regular TLS/DTLS and does not need to be cTLS specific.