### PR TITLE
Remove the open issue regarding profile ids

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -777,8 +777,6 @@ added in the registry has the following form:
 > RFC EDITOR: Please replace the value TBD with the value assigned by IANA, and
 the value XXXX to the RFC number assigned for this document.
 
-> OPEN ISSUE: Should we require standards action for all profile IDs that would fit in 2 octets.
-
 ## Template Keys
 
 This document requests that IANA open a new registry entitled "cTLS Template Keys", on the Transport Layer Security (TLS) Parameters page, with a "Specification Required" registration policy and the following initial contents:


### PR DESCRIPTION
Removed this sentence: 

> OPEN ISSUE: Should we require standards action for all profile IDs that would fit in 2 octets.

The current draft already offers an allocation policy.