### PR TITLE
Section "Adding a cTLS Template message type"

### DIFF
--- a/draft-ietf-tls-ctls.md
+++ b/draft-ietf-tls-ctls.md
@@ -807,7 +807,7 @@ IANA is requested to add the following entry to the TLS HandshakeType registry.
 
 * Value: TBD
 * Description: ctls_template
-* DTLS-OK: ??? Not clear what to put here.
+* DTLS-OK: Y
 * Reference: (This document)
 * Comment: Virtual message used in cTLS.
 


### PR DESCRIPTION
For the ctls_template message type it is OK to set the DTLS-OK field to "Y". The entire message is not applicable to regular TLS/DTLS and hence there is no harm whatever value is in the IANA registry.